### PR TITLE
Fix to portfolio popup

### DIFF
--- a/public/js/init.js
+++ b/public/js/init.js
@@ -104,7 +104,7 @@
 
     $('.item-wrap a').magnificPopup({
 
-       type:'inline',
+       type: 'image',
        fixedContentPos: false,
        removalDelay: 200,
        showCloseBtn: false,

--- a/src/components/portfolio/portfolio.js
+++ b/src/components/portfolio/portfolio.js
@@ -13,7 +13,7 @@ export default class Porfolio extends Component {
               return(
                 <div className="columns portfolio-item">
                   <div className="item-wrap">
-                    <a href="#modal-01">
+                    <a href="#modal-01" data-mfp-src={`./${item.imgurl}`}>
                       <img src={`${item.imgurl}`} className="item-img"/>
                       <div className="overlay">
                         <div className="portfolio-item-meta">


### PR DESCRIPTION
When clicking on a portfolio image magnificPopup shows 'Content Not Found', this change fixes it so it references the image and defines the content as an image.  Fix was implemented in my own project here: https://aceluby.github.io/resume/